### PR TITLE
Improve performance by using "this" instead of "that"

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,15 +31,15 @@ function fast (functions, context) {
     var that = this
 
     this._next = function () {
-      if (that.i === that.functionsLen) {
-        that.done.call(that.context, null, that.value)
-        holder.release(that)
+      if (this.i === this.functionsLen) {
+        this.done.call(this.context, null, this.value)
+        holder.release(this)
         return
       }
-      var res = that.iterator(that.functions[that.i++], that.value, that._done)
+      var res = this.iterator(this.functions[this.i++], this.value, this._done)
       if (res && typeof res.then === 'function') {
-        res.then(that._resolve)
-           .catch(that._reject)
+        res.then(this._resolve)
+           .catch(this._reject)
       }
     }
 


### PR DESCRIPTION
`_next()` is always called as `that._next()` so inside `_next()` you can always use `this`.

This improves performance by about 9%.

```
before x 7,963,270 ops/sec ±0.40% (96 runs sampled)
after x 8,718,081 ops/sec ±1.04% (95 runs sampled)
```

Same [benchmark](https://gist.github.com/nwoltman/c9afe66ee407562feeca0535cd12c4b8) as my last PR, run on Node 9.4.0.